### PR TITLE
Leverage pnpx to work with global packages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
     "start": "next start",
     "lint": "next lint && pnpm check-types",
     "check-types": "tsc --noEmit",
-    "update-types-local": "supabase gen types typescript --local > src/server/supabase/supabaseTypes.ts",
-    "update-types-remote": "supabase gen types typescript --project-id \"<YOUR_PROJECT_ID>\" --schema public > src/server/supabase/supabaseTypes.ts",
+    "update-types-local": "npx supabase gen types typescript --local > src/server/supabase/supabaseTypes.ts",
+    "update-types-remote": "npx supabase gen types typescript --project-id \"<YOUR_PROJECT_ID>\" --schema public > src/server/supabase/supabaseTypes.ts",
     "prepare:local": "pnpm update-types-local && pnpm prisma db pull && pnpm prisma generate && pnpm prisma-case-format --file prisma/schema.prisma  && pnpm prisma generate",
     "prepare:remote": "pnpm update-types-remote && pnpm prisma db pull && pnpm prisma generate && pnpm prisma-case-format --file prisma/schema.prisma  && pnpm prisma generate",
-    "db:reset": "supabase db reset",
-    "db:start": "supabase start",
-    "db:stop": "supabase stop",
-    "db:diff": "supabase db diff -f"
+    "db:reset": "npx supabase db reset",
+    "db:start": "npx supabase start",
+    "db:stop": "npx supabase stop",
+    "db:diff": "npx supabase db diff -f"
   },
   "dependencies": {
     "@prisma/client": "^5.6.0",


### PR DESCRIPTION
## Motivation and context

As stated in https://github.com/Jaaneek/t3-supabase-app-router/issues/9 the repo does not run crucial scripts without modification when run without global Supabase and Prisma installs. This resolves the issue by relying on `pnpx`, `pnpm`'s `npx` equivalent.

## Description

Leverage pnpx instead of installing packages globally

## Steps to reproduce the behavior

1. Yank out globally-installed Supabase and Prisma packages from a system 
2. Run `pnpm run prepare:local`

