### PR TITLE
Render null within PrivateRouteBase. Closes #12

### DIFF
--- a/src/components/PrivateRoute/PrivateRoute.tsx
+++ b/src/components/PrivateRoute/PrivateRoute.tsx
@@ -5,7 +5,8 @@ import { PrivateRouteBase } from "./PrivateRouteBase";
 export const PrivateRoute = async ({ children }: PropsWithChildren) => {
   const user = await getServerUser();
 
-  if (!user) return null; // Prevent server side render of authorized page
+  // prevent server side render of authorized page
+  const view = !user ? null : children;
 
-  return <PrivateRouteBase>{children}</PrivateRouteBase>;
+  return <PrivateRouteBase>{view}</PrivateRouteBase>;
 };


### PR DESCRIPTION
## Motivation and context

This fixes the issue described in issue #12. 


## Description

With this change the server renders nothing for unauthenticated users on private routes _**but**_ the client will also be able to act on this scenario, redirecting them as expected.

## Steps to reproduce the behavior
### Before: 
Navigate to a private route without being authenticated and you will view a blank page. 

### After:
Navigate to a private route without being authenticated and you will view a blank page before being redirected by the useEffect hook within `withPrivateRoute`.

