### PR TITLE
Redirect unauthorized reqests within PrivateRoute. Closes #12

### DIFF
--- a/src/components/PrivateRoute/PrivateRoute.tsx
+++ b/src/components/PrivateRoute/PrivateRoute.tsx
@@ -1,11 +1,12 @@
 import { type PropsWithChildren } from "react";
 import { getServerUser } from "~/utils/auth";
 import { PrivateRouteBase } from "./PrivateRouteBase";
+import { redirect } from "next/navigation";
 
 export const PrivateRoute = async ({ children }: PropsWithChildren) => {
   const user = await getServerUser();
 
-  if (!user) return null; // Prevent server side render of authorized page
+  if (!user) redirect("/login");
 
   return <PrivateRouteBase>{children}</PrivateRouteBase>;
 };


### PR DESCRIPTION
# Motivation and context
This fixes the issue described in issue https://github.com/Jaaneek/t3-supabase-app-router/issues/12.

## Description
With this change the server redirects unauthenticated users on private routes.

## Steps to reproduce the behavior
**Before:**
Navigate to a private route without being authenticated and you will view a blank page.

**After:**
Navigate to a private route without being authenticated and the server redirects to login.